### PR TITLE
Performance Improvements

### DIFF
--- a/gamemode/core/cl_menu_lastrequest.lua
+++ b/gamemode/core/cl_menu_lastrequest.lua
@@ -84,8 +84,8 @@ function JB.MENU_LR()
 		btn_accept.OnMouseReleased = (function()
 			local Menu = DermaMenu()
 
-			for k,v in pairs(team.GetPlayers(TEAM_GUARD))do
-				if not IsValid(v) then continue end
+			for k,v in pairs(player.GetAll())do
+				if v:Team() ~= TEAM_GUARD and not v:Alive() then continue end
 				
 				local btn = Menu:AddOption( v:Nick() or "Unknown guard",function() 
 					RunConsoleCommand("jb_lastrequest_start",lr_selected:GetID(),v:EntIndex());
@@ -99,8 +99,8 @@ function JB.MENU_LR()
 			Menu:AddSpacer()
 			Menu:AddOption( "Random guard",function()
 				local tab = {};
-				for k,v in ipairs(team.GetPlayers(TEAM_GUARD))do
-					if v:Alive() then 
+				for k,v in pairs(player.GetAll())do
+					if v:Alive() and v:Team() == TEAM_GUARD then 
 						table.insert(tab,v);
 					end					
 				end

--- a/gamemode/core/cl_menu_lastrequest.lua
+++ b/gamemode/core/cl_menu_lastrequest.lua
@@ -85,7 +85,7 @@ function JB.MENU_LR()
 			local Menu = DermaMenu()
 
 			for k,v in pairs(player.GetAll())do
-				if v:Team() ~= TEAM_GUARD and not v:Alive() then continue end
+				if v:Team() ~= TEAM_GUARD or not v:Alive() then continue end
 				
 				local btn = Menu:AddOption( v:Nick() or "Unknown guard",function() 
 					RunConsoleCommand("jb_lastrequest_start",lr_selected:GetID(),v:EntIndex());

--- a/gamemode/core/sh_player_meta.lua
+++ b/gamemode/core/sh_player_meta.lua
@@ -17,7 +17,7 @@
 -- ##     Dissemination of this information or reproduction of this material         ##
 -- ##     is strictly forbidden unless prior written permission is obtained          ##
 -- ##     from Casual Bananas                                                        ##
--- ##                                                                                ##
+-- ##                                                             n                   ##
 -- ##     _________________________                                                  ##
 -- ##                                                                                ##
 -- ##                                                                                ##
@@ -31,14 +31,11 @@
 -- ####################################################################################
 
 
-
 local pmeta = FindMetaTable("Player");
 function pmeta:CanPickupWeapon(entity)
-	if table.Count(self:GetWeapons()) > 0 then
-		for k,v in pairs(self:GetWeapons()) do
-			if v.Slot == entity.Slot or v:GetClass() == entity:GetClass() then
-				return false
-			end
+	for k,v in pairs(self:GetWeapons()) do
+		if v.Slot == entity.Slot or v:GetClass() == entity:GetClass() then
+			return false
 		end
 	end
 

--- a/gamemode/core/sh_teams.lua
+++ b/gamemode/core/sh_teams.lua
@@ -30,9 +30,11 @@
 -- ##                                                                                ##
 -- ####################################################################################
 
+local team, table = team, table
 
 TEAM_GUARD 		= 2;
 TEAM_PRISONER 	= 1;
+
 JB.Gamemode.CreateTeams = function()
 	team.SetUp( TEAM_GUARD, "Guards", JB.Color["#0066FF"]	)
 	team.SetUp( TEAM_PRISONER, "Prisoners", JB.Color["#E31100"] )
@@ -43,26 +45,67 @@ JB.Gamemode.CreateTeams = function()
 end
 
 -- Utility functions
+function team.HasPlayers(tm, amount)
+	if not isnumber(amount) or amount < 2 then 
+		for k, v in ipairs(player.GetAll()) do 
+			if v:Team() == tm then return true end
+		end
+		return false
+	else
+		local i = 0
+		for k, v in ipairs(player.GetAll()) do 
+			if v:Team() == tm then 
+				i = i + 1 
+				if i >= amount then 
+					return true
+				end
+			end
+		end
+		return false
+	end
+end
+
+function team.GetAllPlayers()
+	local t = {}
+	for k, v in pairs(team.GetAllTeams()) do
+		t[k] = {}
+	end
+	for k, v in ipairs(player.GetAll()) do 
+		table.insert(t[v:Team()], v)
+	end
+	return t
+end
+
+function team.GetPlayers(tm) -- ran between 1.5x-2x faster in my test. (Ran with JIT enabled)
+	local t = {}
+	for k, v in pairs(player.GetAll()) do
+		if v:Team() == tm then
+			table.insert(t, v)
+		end
+	end
+	return t
+end
+
 function JB:GetGuardsAllowed()
-    if #team.GetPlayers(TEAM_GUARD) <= 0 then
+	local t = team.GetAllPlayers()
+    if #t[TEAM_GUARD] < 1 then
         return 1;
     end
-    return math.ceil((#team.GetPlayers(TEAM_GUARD) + #team.GetPlayers(TEAM_PRISONER)) * (tonumber(JB.Config.guardsAllowed)/100));
+    return math.ceil((#t[TEAM_GUARD] + #t[TEAM_PRISONER]) * (tonumber(JB.Config.guardsAllowed)/100));
 end
 
 function JB:BalanceTeams()
-	if ( #team.GetPlayers(TEAM_GUARD) + #team.GetPlayers(TEAM_PRISONER) ) <= 1 then return end
+	local t = team.GetAllPlayers()
+	if ( #t[TEAM_GUARD] + #t[TEAM_PRISONER] ) <= 1 then return end
 
 	local balls = {};
 	
-	if #team.GetPlayers(TEAM_GUARD) > JB:GetGuardsAllowed() then
-		for i=1, (#team.GetPlayers(TEAM_GUARD) - JB:GetGuardsAllowed()) do
-			local ply = table.Random(team.GetPlayers(TEAM_GUARD));
-			if IsValid(ply) then
-				ply:SetTeam(TEAM_PRISONER);
-				ply:ChatPrint("You were moved to Prisoners to make the game more fair.");
-				balls[#balls+1] = ply;
-			end
+	if #t[TEAM_GUARD] > JB:GetGuardsAllowed() then
+		for i=1, (#t[TEAM_GUARD] - JB:GetGuardsAllowed()) do
+			local ply = table.Random(t[TEAM_GUARD]);
+			ply:SetTeam(TEAM_PRISONER);
+			ply:ChatPrint("You were moved to Prisoners to make the game more fair.");
+			balls[#balls+1] = ply;
 		end
 	end
 	
@@ -72,8 +115,8 @@ end
 local count;
 function JB:AliveGuards()
 	count=0;
-	for _,v in pairs(team.GetPlayers(TEAM_GUARD))do
-		if v:Alive() then
+	for _,v in ipairs(player.GetAll())do
+		if v:Alive() and v:Team() == TEAM_GUARD then
 			count = count+1;
 		end
 	end
@@ -82,8 +125,8 @@ end
 
 function JB:AlivePrisoners()
 	count=0;
-	for _,v in pairs(team.GetPlayers(TEAM_PRISONER))do
-		if v:Alive() then
+	for _,v in ipairs(player.GetAll())do
+		if v:Alive() and v:Team() == TEAM_PRISONER then
 			count = count+1;
 		end
 	end

--- a/gamemode/core/sv_player.lua
+++ b/gamemode/core/sv_player.lua
@@ -72,7 +72,7 @@ JB.Gamemode.PlayerCanPickupWeapon = function( gm, ply, entity )
 
 	if not ply:CanPickupWeapon(entity) then return false end
 
-	if entity.IsDropped and (not entity.BeingPickedUp or entity.BeingPickedUp ~= ply) then
+	if entity.IsDropped and entity.BeingPickedUp ~= ply then
 		return false;
 	end
 
@@ -99,8 +99,8 @@ JB.Gamemode.PlayerDeath = function(gm, victim, weapon, killer)
 	if victim.GetWarden and IsValid(JB.TRANSMITTER) and JB.TRANSMITTER:GetJBWarden() == victim:GetWarden() then
 		JB:BroadcastNotification("The warden has died")
 		timer.Simple(.5,function()
-			for k,v in pairs(team.GetPlayers(TEAM_GUARD))do
-				if v:Alive() and v ~= victim then
+			for k,v in pairs(player.GetAll())do
+				if v:Team() == TEAM_GUARD and v:Alive() and v ~= victim then
 					JB:BroadcastNotification("Prisoners get freeday");
 					break;
 				end

--- a/gamemode/core/sv_spectator.lua
+++ b/gamemode/core/sv_spectator.lua
@@ -41,13 +41,8 @@ JB.Gamemode.PlayerSpawnAsSpectator = function(gm,ply)
 	end
 
 	local canspec = {};
-	for _,v in ipairs(team.GetPlayers(TEAM_GUARD))do
-		if IsValid(v) and v:Alive() then
-			table.insert(canspec,v);
-		end
-	end
-	for _,v in ipairs(team.GetPlayers(TEAM_PRISONER))do
-		if IsValid(v) and v:Alive() then
+	for _,v in ipairs(player.GetAll())do
+		if v:Alive() and (v:Team() == TEAM_GUARD or v:Team() == TEAM_PRISONER) then
 			table.insert(canspec,v);
 		end
 	end
@@ -76,13 +71,8 @@ hook.Add( "KeyPress", "JB.KeyPress.HandleSpectateControls", function(p,key)
 			if not p.spec then p.spec = 1 end
 
 			local canspec = {};
-			for _,v in ipairs(team.GetPlayers(TEAM_GUARD))do
-				if IsValid(v) and v:Alive() then
-					table.insert(canspec,v);
-				end
-			end
-			for _,v in ipairs(team.GetPlayers(TEAM_PRISONER))do
-				if IsValid(v) and v:Alive() then
+			for _,v in ipairs(player.GetAll())do
+				if v:Alive() and (v:Team() == TEAM_GUARD or v:Team() == TEAM_PRISONER) then
 					table.insert(canspec,v);
 				end
 			end

--- a/gamemode/core/sv_warden.lua
+++ b/gamemode/core/sv_warden.lua
@@ -47,8 +47,8 @@ local function claimWarden(p,c,a)
 		p.wardenRounds = p.wardenRounds + 1;
 	end
 
-	for _,v in pairs(team.GetPlayers(TEAM_GUARD))do
-		if IsValid(v) and v ~= p and p.wardenRounds then 
+	for _,v in ipairs(player.GetAll())do
+		if v:Team() == TEAM_GUARD and v ~= p and p.wardenRounds then 
 			p.wardenRounds = 0;
 		end
 	end
@@ -77,20 +77,26 @@ concommand.Add("jb_warden_changecontrol",function(p,c,a)
 
 	hook.Call("JailBreakWardenControlChanged",JB.Gamemode,p,opt,val);
 end);
-
+ 
+JB.WardenProps = {}
+hook.Add("JailBreakRoundEnd", "Clear WardenProps", function()
+	JB.WardenProps = {}
+end)
 local function spawnProp(p,typ,model)
 	local spawned = 0;
-	for k,v in pairs(ents.GetAll())do
-		if v and IsValid(v) and v.wardenSpawned then
+	for k,v in pairs(JB.WardenProps)do
+		if IsValid(v) then
 			spawned = spawned + 1;
+			if spawned > tonumber(JB.Config.maxWardenItems) then
+				p:SendQuickNotification("You can not spawn over "..tostring(JB.Config.maxWardenItems).." items.");	
+				return
+			end
 		end
 	end
-	if spawned > tonumber(JB.Config.maxWardenItems) then
-		p:SendQuickNotification("You can not spawn over "..tostring(JB.Config.maxWardenItems).." items.");
-		return
-	end
-
+	
 	local prop = ents.Create(typ);
+	if not IsValid(prop) then return end
+	table.insert(JB.WardenProps, prop)
 	prop:SetAngles(p:GetAngles());
 	prop:SetPos(p:EyePos() + p:GetAngles():Forward() * 60);
 	


### PR DESCRIPTION
- Remove useless code from team.GetPlayers providing overall performance increase
- Optimize a lot of loops that looped over team.GetPlayers
- Use on average quicker method to determine if a team has players.
- Remove useless table.Count from pmeta:CanPickupWeapon

Tested in a local server and on a live server.