### PR TITLE
Fix invalid pickup log spam

### DIFF
--- a/gamemode/core/sv_player_commands.lua
+++ b/gamemode/core/sv_player_commands.lua
@@ -65,9 +65,9 @@ local pickup = function(p)
 
 	if IsValid(e) and p:Alive() and p:CanPickupWeapon( e )  then
 		e.BeingPickedUp = p;
+		JB:DamageLog_AddPlayerPickup( p,e:GetClass() )
 	end
 
-	JB:DamageLog_AddPlayerPickup( p,e:GetClass() )
 end
 concommand.Add("jb_pickup",pickup)
 JB.Util.addChatCommand("pickup",pickup);


### PR DESCRIPTION
jb_pickup added the entity pickup to the log even if it's an invalid entity (worldspawn is a common one). This caused unintentional log spam but also allows people to spam the jb_pickup command to fill the logs to the point where they don't fully network.