### PR TITLE
fix spectator weapon bug

### DIFF
--- a/gamemode/core/sv_player.lua
+++ b/gamemode/core/sv_player.lua
@@ -93,7 +93,7 @@ JB.Gamemode.IsSpawnpointSuitable = function()
 end
 
 JB.Gamemode.PlayerDeath = function(gm, victim, weapon, killer)
-
+	victim:StripWeapons()
 	victim:SendNotification("You are muted until the round ends")
 
 	if victim.GetWarden and IsValid(JB.TRANSMITTER) and JB.TRANSMITTER:GetJBWarden() == victim:GetWarden() then


### PR DESCRIPTION
Calling StripWeapons in sv_player.lua in the PlayerDeath hook seems to fix the issue described in https://github.com/kurt-stolle/jailbreak/issues/16